### PR TITLE
Changed URL to IGTF repository GPG key

### DIFF
--- a/tasks/igtf_cas.yml
+++ b/tasks/igtf_cas.yml
@@ -29,7 +29,7 @@
 
 - name: "add EGI IGTF repository key"
   get_url:
-    url: "https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3"
+    url: "https://dl.igtf.net/distribution/current/GPG-KEY-EUGridPMA-RPM-4"
     dest: /etc/apt/keyrings/igtf.asc
     force: false
 


### PR DESCRIPTION
- Key has changed as noted in EGI broadcast message from 5/5/2025.